### PR TITLE
Core 도메인 모델 구현

### DIFF
--- a/kafka-dlq-handler-core/src/main/kotlin/io/github/kayden/dlq/core/model/DLQRecord.kt
+++ b/kafka-dlq-handler-core/src/main/kotlin/io/github/kayden/dlq/core/model/DLQRecord.kt
@@ -1,0 +1,143 @@
+package io.github.kayden.dlq.core.model
+
+import java.util.UUID
+
+/**
+ * DLQ 메시지를 나타내는 핵심 도메인 모델.
+ * 
+ * 이 클래스는 프레임워크 독립적인 순수 Kotlin data class로 구현되었으며,
+ * 고성능 메시지 처리를 위해 ByteArray를 사용하여 zero-copy 연산을 지원한다.
+ * 
+ * @property id 메시지의 고유 식별자
+ * @property messageKey Kafka 메시지 키
+ * @property originalTopic 원본 메시지가 발행된 토픽
+ * @property originalPartition 원본 메시지의 파티션 번호
+ * @property originalOffset 원본 메시지의 오프셋
+ * @property payload 메시지 페이로드 (ByteArray로 저장하여 zero-copy 지원)
+ * @property headers 메시지 헤더 맵 (key-value 모두 ByteArray)
+ * @property errorClass 발생한 예외의 클래스명
+ * @property errorMessage 에러 메시지
+ * @property errorType 에러 타입 분류
+ * @property stackTrace 스택 트레이스 (디버깅용)
+ * @property status DLQ 메시지의 현재 상태
+ * @property retryCount 재시도 횟수
+ * @property lastRetryAt 마지막 재시도 시간 (epoch milliseconds)
+ * @property processingMetadata 처리 관련 메타데이터
+ * @property createdAt 생성 시간 (epoch milliseconds)
+ * @property updatedAt 마지막 수정 시간 (epoch milliseconds)
+ * 
+ * @since 0.1.0
+ */
+data class DLQRecord(
+    val id: String = UUID.randomUUID().toString(),
+    val messageKey: String?,
+    val originalTopic: String,
+    val originalPartition: Int,
+    val originalOffset: Long,
+    val payload: ByteArray,
+    val headers: Map<String, ByteArray>,
+    val errorClass: String?,
+    val errorMessage: String?,
+    val errorType: ErrorType,
+    val stackTrace: String?,
+    val status: DLQStatus = DLQStatus.PENDING,
+    val retryCount: Int = 0,
+    val lastRetryAt: Long? = null,
+    val processingMetadata: ProcessingMetadata? = null,
+    val createdAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis()
+) {
+    init {
+        require(originalTopic.isNotBlank()) { "Original topic must not be blank" }
+        require(originalPartition >= 0) { "Original partition must not be negative" }
+        require(originalOffset >= 0) { "Original offset must not be negative" }
+        require(retryCount >= 0) { "Retry count must not be negative" }
+        require(payload.isNotEmpty()) { "Payload must not be empty" }
+    }
+
+    /**
+     * 지연 초기화를 통한 페이로드 문자열 변환.
+     * 성능 최적화를 위해 실제로 필요한 경우에만 변환이 수행된다.
+     */
+    val payloadAsString: String by lazy { 
+        String(payload, Charsets.UTF_8) 
+    }
+    
+    /**
+     * 지연 초기화를 통한 헤더 문자열 맵 변환.
+     * 성능 최적화를 위해 실제로 필요한 경우에만 변환이 수행된다.
+     */
+    val headersAsStringMap: Map<String, String> by lazy {
+        headers.mapValues { (_, value) -> String(value, Charsets.UTF_8) }
+    }
+    
+    /**
+     * 메시지 키의 문자열 변환 (null-safe).
+     */
+    val messageKeyAsString: String? by lazy {
+        messageKey
+    }
+    
+    /**
+     * 재처리 가능 여부를 판단한다.
+     * 
+     * @param maxRetries 최대 재시도 횟수
+     * @return 재처리 가능하면 true
+     */
+    fun canRetry(maxRetries: Int = 3): Boolean =
+        status in listOf(DLQStatus.PENDING, DLQStatus.RETRYING, DLQStatus.FAILED) &&
+        retryCount < maxRetries &&
+        errorType != ErrorType.PERMANENT_FAILURE
+    
+    /**
+     * 재시도를 위한 새로운 인스턴스를 생성한다.
+     * 
+     * @return 재시도 상태로 업데이트된 새 인스턴스
+     */
+    fun withRetry(): DLQRecord = copy(
+        status = DLQStatus.RETRYING,
+        retryCount = retryCount + 1,
+        lastRetryAt = System.currentTimeMillis(),
+        updatedAt = System.currentTimeMillis()
+    )
+    
+    /**
+     * 상태를 업데이트한 새로운 인스턴스를 생성한다.
+     * 
+     * @param newStatus 새로운 상태
+     * @return 상태가 업데이트된 새 인스턴스
+     */
+    fun withStatus(newStatus: DLQStatus): DLQRecord = copy(
+        status = newStatus,
+        updatedAt = System.currentTimeMillis()
+    )
+    
+    /**
+     * 처리 메타데이터를 업데이트한 새로운 인스턴스를 생성한다.
+     * 
+     * @param metadata 새로운 처리 메타데이터
+     * @return 메타데이터가 업데이트된 새 인스턴스
+     */
+    fun withProcessingMetadata(metadata: ProcessingMetadata): DLQRecord = copy(
+        processingMetadata = metadata,
+        updatedAt = System.currentTimeMillis()
+    )
+    
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DLQRecord) return false
+        return id == other.id
+    }
+    
+    override fun hashCode(): Int = id.hashCode()
+    
+    override fun toString(): String {
+        return "DLQRecord(" +
+            "id='$id', " +
+            "originalTopic='$originalTopic', " +
+            "status=$status, " +
+            "retryCount=$retryCount, " +
+            "errorType=$errorType" +
+            ")"
+    }
+}

--- a/kafka-dlq-handler-core/src/main/kotlin/io/github/kayden/dlq/core/model/DLQStatus.kt
+++ b/kafka-dlq-handler-core/src/main/kotlin/io/github/kayden/dlq/core/model/DLQStatus.kt
@@ -1,0 +1,103 @@
+package io.github.kayden.dlq.core.model
+
+/**
+ * DLQ 메시지의 처리 상태를 나타내는 열거형.
+ * 
+ * 각 상태는 메시지가 DLQ 처리 파이프라인에서 어떤 단계에 있는지를 나타낸다.
+ * 
+ * @since 0.1.0
+ */
+enum class DLQStatus {
+    /**
+     * 초기 상태. 메시지가 DLQ에 추가되었지만 아직 처리되지 않은 상태.
+     */
+    PENDING,
+    
+    /**
+     * 재처리 중. 메시지가 현재 재처리되고 있는 상태.
+     */
+    RETRYING,
+    
+    /**
+     * 성공. 메시지가 성공적으로 재처리되어 원본 토픽으로 전송된 상태.
+     */
+    SUCCESS,
+    
+    /**
+     * 실패. 재처리가 실패한 상태. 재시도 가능할 수 있음.
+     */
+    FAILED,
+    
+    /**
+     * 만료. 재시도 제한 또는 시간 제한을 초과하여 더 이상 처리하지 않는 상태.
+     */
+    EXPIRED,
+    
+    /**
+     * 건너뜀. 특정 조건에 의해 처리를 건너뛴 상태.
+     * 예: 영구 실패 타입, 특정 에러 타입 등.
+     */
+    SKIPPED,
+    
+    /**
+     * 보류. 수동 개입이 필요하거나 특정 조건이 충족될 때까지 대기하는 상태.
+     */
+    ON_HOLD;
+    
+    /**
+     * 터미널 상태인지 확인한다.
+     * 터미널 상태는 더 이상 상태 변경이 일어나지 않는 최종 상태를 의미한다.
+     * 
+     * @return 터미널 상태이면 true
+     */
+    fun isTerminal(): Boolean = this in terminalStates
+    
+    /**
+     * 활성 상태인지 확인한다.
+     * 활성 상태는 현재 처리 중이거나 처리 대기 중인 상태를 의미한다.
+     * 
+     * @return 활성 상태이면 true
+     */
+    fun isActive(): Boolean = this in activeStates
+    
+    /**
+     * 재시도 가능한 상태인지 확인한다.
+     * 
+     * @return 재시도 가능한 상태이면 true
+     */
+    fun isRetryable(): Boolean = this in retryableStates
+    
+    companion object {
+        /**
+         * 터미널 상태 집합. 더 이상 상태 변경이 없는 최종 상태들.
+         */
+        val terminalStates = setOf(SUCCESS, EXPIRED, SKIPPED)
+        
+        /**
+         * 활성 상태 집합. 처리 중이거나 처리 대기 중인 상태들.
+         */
+        val activeStates = setOf(PENDING, RETRYING, ON_HOLD)
+        
+        /**
+         * 재시도 가능한 상태 집합.
+         */
+        val retryableStates = setOf(PENDING, FAILED)
+        
+        /**
+         * 상태 전환이 유효한지 검증한다.
+         * 
+         * @param from 현재 상태
+         * @param to 전환하려는 상태
+         * @return 유효한 전환이면 true
+         */
+        fun isValidTransition(from: DLQStatus, to: DLQStatus): Boolean {
+            return when (from) {
+                PENDING -> to in setOf(RETRYING, SKIPPED, ON_HOLD, EXPIRED)
+                RETRYING -> to in setOf(SUCCESS, FAILED, EXPIRED)
+                FAILED -> to in setOf(RETRYING, EXPIRED, SKIPPED, ON_HOLD)
+                ON_HOLD -> to in setOf(PENDING, SKIPPED, EXPIRED)
+                SUCCESS, EXPIRED, SKIPPED -> false // 터미널 상태에서는 전환 불가
+            }
+        }
+    }
+}

--- a/kafka-dlq-handler-core/src/main/kotlin/io/github/kayden/dlq/core/model/ErrorType.kt
+++ b/kafka-dlq-handler-core/src/main/kotlin/io/github/kayden/dlq/core/model/ErrorType.kt
@@ -1,0 +1,193 @@
+package io.github.kayden.dlq.core.model
+
+/**
+ * DLQ 메시지의 에러 타입을 분류하는 열거형.
+ * 
+ * 에러 타입은 재처리 전략을 결정하는 중요한 요소이며,
+ * 일시적 에러와 영구적 에러를 구분하여 적절한 처리 방식을 선택한다.
+ * 
+ * @since 0.1.0
+ */
+enum class ErrorType {
+    /**
+     * 일시적 네트워크 에러.
+     * 네트워크 연결 실패, 타임아웃 등의 일시적인 네트워크 문제.
+     * 일반적으로 재시도로 해결 가능.
+     */
+    TRANSIENT_NETWORK_ERROR,
+    
+    /**
+     * 일시적 서비스 에러.
+     * 외부 서비스 일시적 장애, 과부하 상태 등.
+     * 백오프 전략을 사용한 재시도로 해결 가능.
+     */
+    TRANSIENT_SERVICE_ERROR,
+    
+    /**
+     * 영구적 실패.
+     * 비즈니스 로직 위반, 데이터 무결성 오류 등.
+     * 재시도해도 해결되지 않는 영구적인 문제.
+     */
+    PERMANENT_FAILURE,
+    
+    /**
+     * 데이터 직렬화/역직렬화 에러.
+     * 메시지 포맷 오류, 인코딩 문제 등.
+     * 데이터 수정 없이는 해결 불가능.
+     */
+    SERIALIZATION_ERROR,
+    
+    /**
+     * 인증/인가 에러.
+     * 권한 부족, 인증 토큰 만료 등.
+     * 자격 증명 갱신으로 해결 가능할 수 있음.
+     */
+    AUTHENTICATION_ERROR,
+    
+    /**
+     * 유효성 검사 에러.
+     * 입력 데이터가 비즈니스 규칙을 위반.
+     * 데이터 수정이 필요한 영구적 에러.
+     */
+    VALIDATION_ERROR,
+    
+    /**
+     * 리소스 부족 에러.
+     * 메모리 부족, 디스크 공간 부족 등.
+     * 리소스 확보 후 재시도 가능.
+     */
+    RESOURCE_EXHAUSTED,
+    
+    /**
+     * 알 수 없는 에러.
+     * 분류되지 않은 예외적인 에러.
+     * 상황에 따라 재시도 전략 결정.
+     */
+    UNKNOWN;
+    
+    /**
+     * 재시도 가능한 에러 타입인지 확인한다.
+     * 
+     * @return 재시도 가능한 타입이면 true
+     */
+    fun isRetryable(): Boolean = this in retryableTypes
+    
+    /**
+     * 일시적 에러 타입인지 확인한다.
+     * 
+     * @return 일시적 에러 타입이면 true
+     */
+    fun isTransient(): Boolean = this in transientTypes
+    
+    /**
+     * 영구적 에러 타입인지 확인한다.
+     * 
+     * @return 영구적 에러 타입이면 true
+     */
+    fun isPermanent(): Boolean = this in permanentTypes
+    
+    /**
+     * 권장 백오프 전략을 반환한다.
+     * 
+     * @return 에러 타입에 따른 권장 백오프 전략
+     */
+    fun recommendedBackoffStrategy(): BackoffStrategy {
+        return when (this) {
+            TRANSIENT_NETWORK_ERROR -> BackoffStrategy.EXPONENTIAL
+            TRANSIENT_SERVICE_ERROR -> BackoffStrategy.EXPONENTIAL_WITH_JITTER
+            RESOURCE_EXHAUSTED -> BackoffStrategy.LINEAR
+            AUTHENTICATION_ERROR -> BackoffStrategy.FIXED
+            else -> BackoffStrategy.NONE
+        }
+    }
+    
+    companion object {
+        /**
+         * 재시도 가능한 에러 타입들.
+         */
+        val retryableTypes = setOf(
+            TRANSIENT_NETWORK_ERROR,
+            TRANSIENT_SERVICE_ERROR,
+            RESOURCE_EXHAUSTED,
+            AUTHENTICATION_ERROR,
+            UNKNOWN
+        )
+        
+        /**
+         * 일시적 에러 타입들.
+         */
+        val transientTypes = setOf(
+            TRANSIENT_NETWORK_ERROR,
+            TRANSIENT_SERVICE_ERROR,
+            RESOURCE_EXHAUSTED
+        )
+        
+        /**
+         * 영구적 에러 타입들.
+         */
+        val permanentTypes = setOf(
+            PERMANENT_FAILURE,
+            SERIALIZATION_ERROR,
+            VALIDATION_ERROR
+        )
+        
+        /**
+         * 예외 클래스명을 기반으로 에러 타입을 추론한다.
+         * 
+         * @param exceptionClassName 예외 클래스명
+         * @return 추론된 에러 타입
+         */
+        fun fromException(exceptionClassName: String?): ErrorType {
+            return when {
+                exceptionClassName == null -> UNKNOWN
+                exceptionClassName.contains("Network", ignoreCase = true) ||
+                exceptionClassName.contains("Timeout", ignoreCase = true) ||
+                exceptionClassName.contains("Connection", ignoreCase = true) -> TRANSIENT_NETWORK_ERROR
+                exceptionClassName.contains("Service", ignoreCase = true) ||
+                exceptionClassName.contains("Unavailable", ignoreCase = true) -> TRANSIENT_SERVICE_ERROR
+                exceptionClassName.contains("Serialization", ignoreCase = true) ||
+                exceptionClassName.contains("Deserialization", ignoreCase = true) ||
+                exceptionClassName.contains("Json", ignoreCase = true) -> SERIALIZATION_ERROR
+                exceptionClassName.contains("Auth", ignoreCase = true) ||
+                exceptionClassName.contains("Permission", ignoreCase = true) ||
+                exceptionClassName.contains("Forbidden", ignoreCase = true) -> AUTHENTICATION_ERROR
+                exceptionClassName.contains("Validation", ignoreCase = true) ||
+                exceptionClassName.contains("Invalid", ignoreCase = true) -> VALIDATION_ERROR
+                exceptionClassName.contains("Memory", ignoreCase = true) ||
+                exceptionClassName.contains("Resource", ignoreCase = true) -> RESOURCE_EXHAUSTED
+                else -> UNKNOWN
+            }
+        }
+    }
+}
+
+/**
+ * 백오프 전략을 정의하는 열거형.
+ */
+enum class BackoffStrategy {
+    /**
+     * 백오프 없음. 즉시 재시도.
+     */
+    NONE,
+    
+    /**
+     * 고정 지연. 항상 동일한 시간 대기.
+     */
+    FIXED,
+    
+    /**
+     * 선형 증가. 재시도마다 일정하게 지연 시간 증가.
+     */
+    LINEAR,
+    
+    /**
+     * 지수 증가. 재시도마다 지연 시간을 2배씩 증가.
+     */
+    EXPONENTIAL,
+    
+    /**
+     * 지터를 포함한 지수 증가. 
+     * 여러 인스턴스의 동시 재시도를 방지하기 위한 무작위 요소 포함.
+     */
+    EXPONENTIAL_WITH_JITTER
+}

--- a/kafka-dlq-handler-core/src/main/kotlin/io/github/kayden/dlq/core/model/ProcessingMetadata.kt
+++ b/kafka-dlq-handler-core/src/main/kotlin/io/github/kayden/dlq/core/model/ProcessingMetadata.kt
@@ -1,0 +1,245 @@
+package io.github.kayden.dlq.core.model
+
+/**
+ * DLQ 메시지 처리와 관련된 메타데이터를 담는 value object.
+ * 
+ * 이 클래스는 불변 객체로 설계되어 thread-safe하며,
+ * 메시지 처리 과정에서 발생하는 다양한 정보를 추적한다.
+ * 
+ * @property processedBy 메시지를 처리한 프로세서/인스턴스 식별자
+ * @property processingDurationMillis 처리에 소요된 시간 (밀리초)
+ * @property batchId 배치 처리 시 배치 식별자
+ * @property attemptNumber 현재 처리 시도 번호
+ * @property nextRetryAt 다음 재시도 예정 시간 (epoch milliseconds)
+ * @property backoffDelayMillis 백오프 지연 시간 (밀리초)
+ * @property tags 추가 메타데이터를 위한 태그 맵
+ * @property metrics 처리 관련 메트릭 정보
+ * 
+ * @since 0.1.0
+ */
+data class ProcessingMetadata(
+    val processedBy: String? = null,
+    val processingDurationMillis: Long? = null,
+    val batchId: String? = null,
+    val attemptNumber: Int = 1,
+    val nextRetryAt: Long? = null,
+    val backoffDelayMillis: Long? = null,
+    val tags: Map<String, String> = emptyMap(),
+    val metrics: ProcessingMetrics? = null
+) {
+    init {
+        require(attemptNumber > 0) { "Attempt number must be positive" }
+        processingDurationMillis?.let {
+            require(it >= 0) { "Processing duration must not be negative" }
+        }
+        backoffDelayMillis?.let {
+            require(it >= 0) { "Backoff delay must not be negative" }
+        }
+    }
+    
+    /**
+     * 태그를 추가한 새로운 인스턴스를 생성한다.
+     * 
+     * @param key 태그 키
+     * @param value 태그 값
+     * @return 태그가 추가된 새 인스턴스
+     */
+    fun withTag(key: String, value: String): ProcessingMetadata =
+        copy(tags = tags + (key to value))
+    
+    /**
+     * 여러 태그를 추가한 새로운 인스턴스를 생성한다.
+     * 
+     * @param newTags 추가할 태그 맵
+     * @return 태그가 추가된 새 인스턴스
+     */
+    fun withTags(newTags: Map<String, String>): ProcessingMetadata =
+        copy(tags = tags + newTags)
+    
+    /**
+     * 처리 시간을 기록한 새로운 인스턴스를 생성한다.
+     * 
+     * @param startTimeMillis 처리 시작 시간
+     * @param endTimeMillis 처리 종료 시간
+     * @return 처리 시간이 기록된 새 인스턴스
+     */
+    fun withProcessingTime(startTimeMillis: Long, endTimeMillis: Long): ProcessingMetadata {
+        require(endTimeMillis >= startTimeMillis) { "End time must be after start time" }
+        return copy(processingDurationMillis = endTimeMillis - startTimeMillis)
+    }
+    
+    /**
+     * 다음 재시도 정보를 설정한 새로운 인스턴스를 생성한다.
+     * 
+     * @param nextRetryTime 다음 재시도 시간
+     * @param backoffDelay 백오프 지연 시간
+     * @return 재시도 정보가 설정된 새 인스턴스
+     */
+    fun withRetryInfo(nextRetryTime: Long, backoffDelay: Long): ProcessingMetadata =
+        copy(
+            nextRetryAt = nextRetryTime,
+            backoffDelayMillis = backoffDelay,
+            attemptNumber = attemptNumber + 1
+        )
+    
+    /**
+     * 메트릭을 업데이트한 새로운 인스턴스를 생성한다.
+     * 
+     * @param metrics 새로운 메트릭 정보
+     * @return 메트릭이 업데이트된 새 인스턴스
+     */
+    fun withMetrics(metrics: ProcessingMetrics): ProcessingMetadata =
+        copy(metrics = metrics)
+    
+    /**
+     * 처리가 성공했는지 확인한다.
+     * 
+     * @return 처리 시간이 기록되어 있으면 true
+     */
+    fun isProcessed(): Boolean = processingDurationMillis != null
+    
+    /**
+     * 재시도가 예정되어 있는지 확인한다.
+     * 
+     * @return 다음 재시도 시간이 설정되어 있으면 true
+     */
+    fun isRetryScheduled(): Boolean = nextRetryAt != null
+    
+    companion object {
+        /**
+         * 빈 메타데이터 인스턴스.
+         */
+        val EMPTY = ProcessingMetadata()
+        
+        /**
+         * 초기 처리를 위한 메타데이터를 생성한다.
+         * 
+         * @param processedBy 프로세서 식별자
+         * @param batchId 배치 식별자 (optional)
+         * @return 초기 처리 메타데이터
+         */
+        fun initial(processedBy: String, batchId: String? = null): ProcessingMetadata =
+            ProcessingMetadata(
+                processedBy = processedBy,
+                batchId = batchId,
+                attemptNumber = 1
+            )
+    }
+}
+
+/**
+ * 처리 관련 메트릭 정보를 담는 data class.
+ * 
+ * @property messagesProcessed 처리된 메시지 수
+ * @property messagesSuccess 성공한 메시지 수
+ * @property messagesFailed 실패한 메시지 수
+ * @property bytesProcessed 처리된 바이트 수
+ * @property throughputMessagesPerSecond 초당 메시지 처리량
+ * @property averageProcessingTimeMillis 평균 처리 시간 (밀리초)
+ * 
+ * @since 0.1.0
+ */
+data class ProcessingMetrics(
+    val messagesProcessed: Long = 0,
+    val messagesSuccess: Long = 0,
+    val messagesFailed: Long = 0,
+    val bytesProcessed: Long = 0,
+    val throughputMessagesPerSecond: Double? = null,
+    val averageProcessingTimeMillis: Double? = null
+) {
+    init {
+        require(messagesProcessed >= 0) { "Messages processed must not be negative" }
+        require(messagesSuccess >= 0) { "Messages success must not be negative" }
+        require(messagesFailed >= 0) { "Messages failed must not be negative" }
+        require(bytesProcessed >= 0) { "Bytes processed must not be negative" }
+        require(messagesSuccess + messagesFailed <= messagesProcessed) {
+            "Success + Failed messages cannot exceed total processed"
+        }
+        throughputMessagesPerSecond?.let {
+            require(it >= 0) { "Throughput must not be negative" }
+        }
+        averageProcessingTimeMillis?.let {
+            require(it >= 0) { "Average processing time must not be negative" }
+        }
+    }
+    
+    /**
+     * 성공률을 계산한다.
+     * 
+     * @return 성공률 (0.0 ~ 1.0), 처리된 메시지가 없으면 null
+     */
+    fun successRate(): Double? {
+        return if (messagesProcessed > 0) {
+            messagesSuccess.toDouble() / messagesProcessed
+        } else {
+            null
+        }
+    }
+    
+    /**
+     * 실패율을 계산한다.
+     * 
+     * @return 실패율 (0.0 ~ 1.0), 처리된 메시지가 없으면 null
+     */
+    fun failureRate(): Double? {
+        return if (messagesProcessed > 0) {
+            messagesFailed.toDouble() / messagesProcessed
+        } else {
+            null
+        }
+    }
+    
+    /**
+     * 메시지당 평균 바이트 수를 계산한다.
+     * 
+     * @return 메시지당 평균 바이트 수, 처리된 메시지가 없으면 null
+     */
+    fun averageBytesPerMessage(): Double? {
+        return if (messagesProcessed > 0) {
+            bytesProcessed.toDouble() / messagesProcessed
+        } else {
+            null
+        }
+    }
+    
+    companion object {
+        /**
+         * 빈 메트릭 인스턴스.
+         */
+        val EMPTY = ProcessingMetrics()
+        
+        /**
+         * 여러 메트릭을 병합한다.
+         * 
+         * @param metrics 병합할 메트릭들
+         * @return 병합된 메트릭
+         */
+        fun merge(vararg metrics: ProcessingMetrics): ProcessingMetrics {
+            if (metrics.isEmpty()) return EMPTY
+            
+            val totalProcessed = metrics.sumOf { it.messagesProcessed }
+            val totalSuccess = metrics.sumOf { it.messagesSuccess }
+            val totalFailed = metrics.sumOf { it.messagesFailed }
+            val totalBytes = metrics.sumOf { it.bytesProcessed }
+            
+            val avgProcessingTime = metrics
+                .mapNotNull { it.averageProcessingTimeMillis }
+                .takeIf { it.isNotEmpty() }
+                ?.average()
+            
+            val avgThroughput = metrics
+                .mapNotNull { it.throughputMessagesPerSecond }
+                .takeIf { it.isNotEmpty() }
+                ?.average()
+            
+            return ProcessingMetrics(
+                messagesProcessed = totalProcessed,
+                messagesSuccess = totalSuccess,
+                messagesFailed = totalFailed,
+                bytesProcessed = totalBytes,
+                throughputMessagesPerSecond = avgThroughput,
+                averageProcessingTimeMillis = avgProcessingTime
+            )
+        }
+    }
+}

--- a/kafka-dlq-handler-core/src/test/kotlin/io/github/kayden/dlq/core/model/DLQRecordTest.kt
+++ b/kafka-dlq-handler-core/src/test/kotlin/io/github/kayden/dlq/core/model/DLQRecordTest.kt
@@ -1,0 +1,235 @@
+package io.github.kayden.dlq.core.model
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import java.util.UUID
+
+class DLQRecordTest {
+    
+    @Test
+    @DisplayName("유효한 데이터로 DLQRecord를 생성할 수 있다")
+    fun shouldCreateDLQRecordWithValidData() {
+        val record = createTestDLQRecord()
+        
+        assertNotNull(record.id)
+        assertEquals("test-key", record.messageKey)
+        assertEquals("test-topic", record.originalTopic)
+        assertEquals(0, record.originalPartition)
+        assertEquals(123L, record.originalOffset)
+        assertArrayEquals("test payload".toByteArray(), record.payload)
+        assertEquals(DLQStatus.PENDING, record.status)
+        assertEquals(0, record.retryCount)
+        assertEquals(ErrorType.TRANSIENT_NETWORK_ERROR, record.errorType)
+    }
+    
+    @Test
+    @DisplayName("빈 토픽 이름으로 생성 시 예외가 발생한다")
+    fun shouldThrowExceptionWhenTopicIsBlank() {
+        assertThrows<IllegalArgumentException> {
+            createTestDLQRecord(originalTopic = "")
+        }.also { exception ->
+            assertEquals("Original topic must not be blank", exception.message)
+        }
+    }
+    
+    @Test
+    @DisplayName("음수 파티션으로 생성 시 예외가 발생한다")
+    fun shouldThrowExceptionWhenPartitionIsNegative() {
+        assertThrows<IllegalArgumentException> {
+            createTestDLQRecord(originalPartition = -1)
+        }.also { exception ->
+            assertEquals("Original partition must not be negative", exception.message)
+        }
+    }
+    
+    @Test
+    @DisplayName("음수 오프셋으로 생성 시 예외가 발생한다")
+    fun shouldThrowExceptionWhenOffsetIsNegative() {
+        assertThrows<IllegalArgumentException> {
+            createTestDLQRecord(originalOffset = -1)
+        }.also { exception ->
+            assertEquals("Original offset must not be negative", exception.message)
+        }
+    }
+    
+    @Test
+    @DisplayName("음수 재시도 횟수로 생성 시 예외가 발생한다")
+    fun shouldThrowExceptionWhenRetryCountIsNegative() {
+        assertThrows<IllegalArgumentException> {
+            createTestDLQRecord(retryCount = -1)
+        }.also { exception ->
+            assertEquals("Retry count must not be negative", exception.message)
+        }
+    }
+    
+    @Test
+    @DisplayName("빈 페이로드로 생성 시 예외가 발생한다")
+    fun shouldThrowExceptionWhenPayloadIsEmpty() {
+        assertThrows<IllegalArgumentException> {
+            createTestDLQRecord(payload = ByteArray(0))
+        }.also { exception ->
+            assertEquals("Payload must not be empty", exception.message)
+        }
+    }
+    
+    @Test
+    @DisplayName("payloadAsString은 지연 로딩되며 올바르게 변환된다")
+    fun shouldLazilyConvertPayloadToString() {
+        val payload = "한글 테스트 메시지".toByteArray()
+        val record = createTestDLQRecord(payload = payload)
+        
+        assertEquals("한글 테스트 메시지", record.payloadAsString)
+    }
+    
+    @Test
+    @DisplayName("headersAsStringMap은 지연 로딩되며 올바르게 변환된다")
+    fun shouldLazilyConvertHeadersToStringMap() {
+        val headers = mapOf(
+            "header1" to "value1".toByteArray(),
+            "header2" to "value2".toByteArray()
+        )
+        val record = createTestDLQRecord(headers = headers)
+        
+        val stringHeaders = record.headersAsStringMap
+        assertEquals(2, stringHeaders.size)
+        assertEquals("value1", stringHeaders["header1"])
+        assertEquals("value2", stringHeaders["header2"])
+    }
+    
+    @Test
+    @DisplayName("canRetry는 재시도 가능한 상태를 올바르게 판단한다")
+    fun shouldDetermineRetryEligibility() {
+        val pendingRecord = createTestDLQRecord(
+            status = DLQStatus.PENDING,
+            retryCount = 2,
+            errorType = ErrorType.TRANSIENT_NETWORK_ERROR
+        )
+        assertTrue(pendingRecord.canRetry(3))
+        assertFalse(pendingRecord.canRetry(2))
+        
+        val successRecord = createTestDLQRecord(
+            status = DLQStatus.SUCCESS,
+            retryCount = 0
+        )
+        assertFalse(successRecord.canRetry())
+        
+        val permanentErrorRecord = createTestDLQRecord(
+            status = DLQStatus.PENDING,
+            retryCount = 0,
+            errorType = ErrorType.PERMANENT_FAILURE
+        )
+        assertFalse(permanentErrorRecord.canRetry())
+    }
+    
+    @Test
+    @DisplayName("withRetry는 재시도 상태로 올바르게 업데이트한다")
+    fun shouldUpdateForRetry() {
+        val original = createTestDLQRecord(retryCount = 1)
+        val beforeUpdate = original.updatedAt
+        
+        Thread.sleep(10)
+        val updated = original.withRetry()
+        
+        assertEquals(DLQStatus.RETRYING, updated.status)
+        assertEquals(2, updated.retryCount)
+        assertNotNull(updated.lastRetryAt)
+        assertTrue(updated.updatedAt > beforeUpdate)
+        assertEquals(original.id, updated.id)
+    }
+    
+    @Test
+    @DisplayName("withStatus는 상태를 올바르게 업데이트한다")
+    fun shouldUpdateStatus() {
+        val original = createTestDLQRecord(status = DLQStatus.PENDING)
+        val updated = original.withStatus(DLQStatus.SUCCESS)
+        
+        assertEquals(DLQStatus.SUCCESS, updated.status)
+        assertEquals(original.id, updated.id)
+        assertEquals(original.retryCount, updated.retryCount)
+    }
+    
+    @Test
+    @DisplayName("withProcessingMetadata는 메타데이터를 올바르게 업데이트한다")
+    fun shouldUpdateProcessingMetadata() {
+        val original = createTestDLQRecord()
+        val metadata = ProcessingMetadata(
+            processedBy = "test-processor",
+            processingDurationMillis = 100
+        )
+        val updated = original.withProcessingMetadata(metadata)
+        
+        assertEquals(metadata, updated.processingMetadata)
+        assertEquals(original.id, updated.id)
+    }
+    
+    @Test
+    @DisplayName("equals와 hashCode는 ID 기반으로 동작한다")
+    fun shouldImplementEqualsAndHashCodeBasedOnId() {
+        val id = UUID.randomUUID().toString()
+        val record1 = createTestDLQRecord(id = id, messageKey = "key1")
+        val record2 = createTestDLQRecord(id = id, messageKey = "key2")
+        val record3 = createTestDLQRecord(messageKey = "key1")
+        
+        assertEquals(record1, record2)
+        assertNotEquals(record1, record3)
+        assertEquals(record1.hashCode(), record2.hashCode())
+        assertNotEquals(record1.hashCode(), record3.hashCode())
+    }
+    
+    @Test
+    @DisplayName("toString은 주요 정보만 포함한다")
+    fun shouldProvideReadableToString() {
+        val record = createTestDLQRecord(
+            id = "test-id",
+            originalTopic = "test-topic",
+            status = DLQStatus.PENDING,
+            retryCount = 2,
+            errorType = ErrorType.TRANSIENT_NETWORK_ERROR
+        )
+        
+        val string = record.toString()
+        assertTrue(string.contains("test-id"))
+        assertTrue(string.contains("test-topic"))
+        assertTrue(string.contains("PENDING"))
+        assertTrue(string.contains("2"))
+        assertTrue(string.contains("TRANSIENT_NETWORK_ERROR"))
+    }
+    
+    private fun createTestDLQRecord(
+        id: String = UUID.randomUUID().toString(),
+        messageKey: String? = "test-key",
+        originalTopic: String = "test-topic",
+        originalPartition: Int = 0,
+        originalOffset: Long = 123L,
+        payload: ByteArray = "test payload".toByteArray(),
+        headers: Map<String, ByteArray> = mapOf("test-header" to "test-value".toByteArray()),
+        errorClass: String? = "java.io.IOException",
+        errorMessage: String? = "Test error",
+        errorType: ErrorType = ErrorType.TRANSIENT_NETWORK_ERROR,
+        stackTrace: String? = null,
+        status: DLQStatus = DLQStatus.PENDING,
+        retryCount: Int = 0,
+        lastRetryAt: Long? = null,
+        processingMetadata: ProcessingMetadata? = null
+    ): DLQRecord {
+        return DLQRecord(
+            id = id,
+            messageKey = messageKey,
+            originalTopic = originalTopic,
+            originalPartition = originalPartition,
+            originalOffset = originalOffset,
+            payload = payload,
+            headers = headers,
+            errorClass = errorClass,
+            errorMessage = errorMessage,
+            errorType = errorType,
+            stackTrace = stackTrace,
+            status = status,
+            retryCount = retryCount,
+            lastRetryAt = lastRetryAt,
+            processingMetadata = processingMetadata
+        )
+    }
+}

--- a/kafka-dlq-handler-core/src/test/kotlin/io/github/kayden/dlq/core/model/DLQStatusTest.kt
+++ b/kafka-dlq-handler-core/src/test/kotlin/io/github/kayden/dlq/core/model/DLQStatusTest.kt
@@ -1,0 +1,164 @@
+package io.github.kayden.dlq.core.model
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.CsvSource
+
+class DLQStatusTest {
+    
+    @Test
+    @DisplayName("터미널 상태를 올바르게 식별한다")
+    fun shouldIdentifyTerminalStates() {
+        assertTrue(DLQStatus.SUCCESS.isTerminal())
+        assertTrue(DLQStatus.EXPIRED.isTerminal())
+        assertTrue(DLQStatus.SKIPPED.isTerminal())
+        
+        assertFalse(DLQStatus.PENDING.isTerminal())
+        assertFalse(DLQStatus.RETRYING.isTerminal())
+        assertFalse(DLQStatus.FAILED.isTerminal())
+        assertFalse(DLQStatus.ON_HOLD.isTerminal())
+    }
+    
+    @Test
+    @DisplayName("활성 상태를 올바르게 식별한다")
+    fun shouldIdentifyActiveStates() {
+        assertTrue(DLQStatus.PENDING.isActive())
+        assertTrue(DLQStatus.RETRYING.isActive())
+        assertTrue(DLQStatus.ON_HOLD.isActive())
+        
+        assertFalse(DLQStatus.SUCCESS.isActive())
+        assertFalse(DLQStatus.FAILED.isActive())
+        assertFalse(DLQStatus.EXPIRED.isActive())
+        assertFalse(DLQStatus.SKIPPED.isActive())
+    }
+    
+    @Test
+    @DisplayName("재시도 가능한 상태를 올바르게 식별한다")
+    fun shouldIdentifyRetryableStates() {
+        assertTrue(DLQStatus.PENDING.isRetryable())
+        assertTrue(DLQStatus.FAILED.isRetryable())
+        
+        assertFalse(DLQStatus.RETRYING.isRetryable())
+        assertFalse(DLQStatus.SUCCESS.isRetryable())
+        assertFalse(DLQStatus.EXPIRED.isRetryable())
+        assertFalse(DLQStatus.SKIPPED.isRetryable())
+        assertFalse(DLQStatus.ON_HOLD.isRetryable())
+    }
+    
+    @ParameterizedTest
+    @CsvSource(
+        "PENDING, RETRYING, true",
+        "PENDING, SKIPPED, true",
+        "PENDING, ON_HOLD, true",
+        "PENDING, EXPIRED, true",
+        "PENDING, SUCCESS, false",
+        "PENDING, FAILED, false",
+        "RETRYING, SUCCESS, true",
+        "RETRYING, FAILED, true",
+        "RETRYING, EXPIRED, true",
+        "RETRYING, PENDING, false",
+        "RETRYING, SKIPPED, false",
+        "FAILED, RETRYING, true",
+        "FAILED, EXPIRED, true",
+        "FAILED, SKIPPED, true",
+        "FAILED, ON_HOLD, true",
+        "FAILED, SUCCESS, false",
+        "ON_HOLD, PENDING, true",
+        "ON_HOLD, SKIPPED, true",
+        "ON_HOLD, EXPIRED, true",
+        "ON_HOLD, RETRYING, false",
+        "SUCCESS, PENDING, false",
+        "SUCCESS, RETRYING, false",
+        "EXPIRED, PENDING, false",
+        "SKIPPED, RETRYING, false"
+    )
+    @DisplayName("상태 전환 유효성을 올바르게 검증한다")
+    fun shouldValidateStateTransitions(from: DLQStatus, to: DLQStatus, expected: Boolean) {
+        assertEquals(
+            expected,
+            DLQStatus.isValidTransition(from, to),
+            "Transition from $from to $to should be ${if (expected) "valid" else "invalid"}"
+        )
+    }
+    
+    @Test
+    @DisplayName("터미널 상태에서는 어떤 상태로도 전환할 수 없다")
+    fun shouldNotAllowTransitionFromTerminalStates() {
+        val terminalStates = listOf(DLQStatus.SUCCESS, DLQStatus.EXPIRED, DLQStatus.SKIPPED)
+        val allStates = DLQStatus.values().toList()
+        
+        for (terminalState in terminalStates) {
+            for (targetState in allStates) {
+                assertFalse(
+                    DLQStatus.isValidTransition(terminalState, targetState),
+                    "Should not allow transition from terminal state $terminalState to $targetState"
+                )
+            }
+        }
+    }
+    
+    @Test
+    @DisplayName("companion object 상태 집합이 올바르게 정의되어 있다")
+    fun shouldHaveCorrectStateCollections() {
+        assertEquals(
+            setOf(DLQStatus.SUCCESS, DLQStatus.EXPIRED, DLQStatus.SKIPPED),
+            DLQStatus.terminalStates
+        )
+        
+        assertEquals(
+            setOf(DLQStatus.PENDING, DLQStatus.RETRYING, DLQStatus.ON_HOLD),
+            DLQStatus.activeStates
+        )
+        
+        assertEquals(
+            setOf(DLQStatus.PENDING, DLQStatus.FAILED),
+            DLQStatus.retryableStates
+        )
+    }
+    
+    @ParameterizedTest
+    @EnumSource(DLQStatus::class)
+    @DisplayName("모든 상태는 정확히 하나의 카테고리에 속한다")
+    fun shouldBelongToExactlyOneCategory(status: DLQStatus) {
+        val categories = listOf(
+            status.isTerminal(),
+            status.isActive(),
+            status == DLQStatus.FAILED
+        )
+        
+        assertEquals(
+            1,
+            categories.count { it },
+            "$status should belong to exactly one category"
+        )
+    }
+    
+    @Test
+    @DisplayName("PENDING 상태의 유효한 전환 경로")
+    fun shouldAllowValidTransitionsFromPending() {
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.PENDING, DLQStatus.RETRYING))
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.PENDING, DLQStatus.SKIPPED))
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.PENDING, DLQStatus.ON_HOLD))
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.PENDING, DLQStatus.EXPIRED))
+    }
+    
+    @Test
+    @DisplayName("RETRYING 상태의 유효한 전환 경로")
+    fun shouldAllowValidTransitionsFromRetrying() {
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.RETRYING, DLQStatus.SUCCESS))
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.RETRYING, DLQStatus.FAILED))
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.RETRYING, DLQStatus.EXPIRED))
+    }
+    
+    @Test
+    @DisplayName("FAILED 상태의 유효한 전환 경로")
+    fun shouldAllowValidTransitionsFromFailed() {
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.FAILED, DLQStatus.RETRYING))
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.FAILED, DLQStatus.EXPIRED))
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.FAILED, DLQStatus.SKIPPED))
+        assertTrue(DLQStatus.isValidTransition(DLQStatus.FAILED, DLQStatus.ON_HOLD))
+    }
+}

--- a/kafka-dlq-handler-core/src/test/kotlin/io/github/kayden/dlq/core/model/ErrorTypeTest.kt
+++ b/kafka-dlq-handler-core/src/test/kotlin/io/github/kayden/dlq/core/model/ErrorTypeTest.kt
@@ -1,0 +1,206 @@
+package io.github.kayden.dlq.core.model
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EnumSource
+
+class ErrorTypeTest {
+    
+    @Test
+    @DisplayName("재시도 가능한 에러 타입을 올바르게 식별한다")
+    fun shouldIdentifyRetryableErrorTypes() {
+        assertTrue(ErrorType.TRANSIENT_NETWORK_ERROR.isRetryable())
+        assertTrue(ErrorType.TRANSIENT_SERVICE_ERROR.isRetryable())
+        assertTrue(ErrorType.RESOURCE_EXHAUSTED.isRetryable())
+        assertTrue(ErrorType.AUTHENTICATION_ERROR.isRetryable())
+        assertTrue(ErrorType.UNKNOWN.isRetryable())
+        
+        assertFalse(ErrorType.PERMANENT_FAILURE.isRetryable())
+        assertFalse(ErrorType.SERIALIZATION_ERROR.isRetryable())
+        assertFalse(ErrorType.VALIDATION_ERROR.isRetryable())
+    }
+    
+    @Test
+    @DisplayName("일시적 에러 타입을 올바르게 식별한다")
+    fun shouldIdentifyTransientErrorTypes() {
+        assertTrue(ErrorType.TRANSIENT_NETWORK_ERROR.isTransient())
+        assertTrue(ErrorType.TRANSIENT_SERVICE_ERROR.isTransient())
+        assertTrue(ErrorType.RESOURCE_EXHAUSTED.isTransient())
+        
+        assertFalse(ErrorType.PERMANENT_FAILURE.isTransient())
+        assertFalse(ErrorType.SERIALIZATION_ERROR.isTransient())
+        assertFalse(ErrorType.VALIDATION_ERROR.isTransient())
+        assertFalse(ErrorType.AUTHENTICATION_ERROR.isTransient())
+        assertFalse(ErrorType.UNKNOWN.isTransient())
+    }
+    
+    @Test
+    @DisplayName("영구적 에러 타입을 올바르게 식별한다")
+    fun shouldIdentifyPermanentErrorTypes() {
+        assertTrue(ErrorType.PERMANENT_FAILURE.isPermanent())
+        assertTrue(ErrorType.SERIALIZATION_ERROR.isPermanent())
+        assertTrue(ErrorType.VALIDATION_ERROR.isPermanent())
+        
+        assertFalse(ErrorType.TRANSIENT_NETWORK_ERROR.isPermanent())
+        assertFalse(ErrorType.TRANSIENT_SERVICE_ERROR.isPermanent())
+        assertFalse(ErrorType.RESOURCE_EXHAUSTED.isPermanent())
+        assertFalse(ErrorType.AUTHENTICATION_ERROR.isPermanent())
+        assertFalse(ErrorType.UNKNOWN.isPermanent())
+    }
+    
+    @Test
+    @DisplayName("에러 타입별 권장 백오프 전략을 올바르게 반환한다")
+    fun shouldReturnCorrectBackoffStrategy() {
+        assertEquals(
+            BackoffStrategy.EXPONENTIAL,
+            ErrorType.TRANSIENT_NETWORK_ERROR.recommendedBackoffStrategy()
+        )
+        assertEquals(
+            BackoffStrategy.EXPONENTIAL_WITH_JITTER,
+            ErrorType.TRANSIENT_SERVICE_ERROR.recommendedBackoffStrategy()
+        )
+        assertEquals(
+            BackoffStrategy.LINEAR,
+            ErrorType.RESOURCE_EXHAUSTED.recommendedBackoffStrategy()
+        )
+        assertEquals(
+            BackoffStrategy.FIXED,
+            ErrorType.AUTHENTICATION_ERROR.recommendedBackoffStrategy()
+        )
+        assertEquals(
+            BackoffStrategy.NONE,
+            ErrorType.PERMANENT_FAILURE.recommendedBackoffStrategy()
+        )
+        assertEquals(
+            BackoffStrategy.NONE,
+            ErrorType.SERIALIZATION_ERROR.recommendedBackoffStrategy()
+        )
+        assertEquals(
+            BackoffStrategy.NONE,
+            ErrorType.VALIDATION_ERROR.recommendedBackoffStrategy()
+        )
+        assertEquals(
+            BackoffStrategy.NONE,
+            ErrorType.UNKNOWN.recommendedBackoffStrategy()
+        )
+    }
+    
+    @ParameterizedTest
+    @CsvSource(
+        "java.net.SocketTimeoutException, TRANSIENT_NETWORK_ERROR",
+        "java.net.ConnectException, TRANSIENT_NETWORK_ERROR",
+        "org.apache.kafka.common.errors.NetworkException, TRANSIENT_NETWORK_ERROR",
+        "io.grpc.StatusRuntimeException, TRANSIENT_SERVICE_ERROR",
+        "javax.ws.rs.ServiceUnavailableException, TRANSIENT_SERVICE_ERROR",
+        "com.fasterxml.jackson.core.JsonParseException, SERIALIZATION_ERROR",
+        "java.io.NotSerializableException, SERIALIZATION_ERROR",
+        "org.springframework.security.access.AccessDeniedException, AUTHENTICATION_ERROR",
+        "javax.security.auth.login.LoginException, AUTHENTICATION_ERROR",
+        "java.lang.SecurityException, AUTHENTICATION_ERROR",
+        "javax.validation.ValidationException, VALIDATION_ERROR",
+        "java.lang.IllegalArgumentException, VALIDATION_ERROR",
+        "java.lang.OutOfMemoryError, RESOURCE_EXHAUSTED",
+        "java.lang.RuntimeException, UNKNOWN",
+        ", UNKNOWN"
+    )
+    @DisplayName("예외 클래스명으로부터 에러 타입을 올바르게 추론한다")
+    fun shouldInferErrorTypeFromException(exceptionClassName: String?, expectedType: ErrorType) {
+        assertEquals(expectedType, ErrorType.fromException(exceptionClassName))
+    }
+    
+    @Test
+    @DisplayName("대소문자를 무시하고 예외 클래스명을 매칭한다")
+    fun shouldMatchExceptionNameIgnoringCase() {
+        assertEquals(
+            ErrorType.TRANSIENT_NETWORK_ERROR,
+            ErrorType.fromException("com.example.NetworkTimeoutException")
+        )
+        assertEquals(
+            ErrorType.TRANSIENT_NETWORK_ERROR,
+            ErrorType.fromException("com.example.NETWORKTIMEOUTEXCEPTION")
+        )
+        assertEquals(
+            ErrorType.AUTHENTICATION_ERROR,
+            ErrorType.fromException("com.example.AuthenticationFailedException")
+        )
+    }
+    
+    @Test
+    @DisplayName("companion object 에러 타입 집합이 올바르게 정의되어 있다")
+    fun shouldHaveCorrectErrorTypeCollections() {
+        assertEquals(
+            setOf(
+                ErrorType.TRANSIENT_NETWORK_ERROR,
+                ErrorType.TRANSIENT_SERVICE_ERROR,
+                ErrorType.RESOURCE_EXHAUSTED,
+                ErrorType.AUTHENTICATION_ERROR,
+                ErrorType.UNKNOWN
+            ),
+            ErrorType.retryableTypes
+        )
+        
+        assertEquals(
+            setOf(
+                ErrorType.TRANSIENT_NETWORK_ERROR,
+                ErrorType.TRANSIENT_SERVICE_ERROR,
+                ErrorType.RESOURCE_EXHAUSTED
+            ),
+            ErrorType.transientTypes
+        )
+        
+        assertEquals(
+            setOf(
+                ErrorType.PERMANENT_FAILURE,
+                ErrorType.SERIALIZATION_ERROR,
+                ErrorType.VALIDATION_ERROR
+            ),
+            ErrorType.permanentTypes
+        )
+    }
+    
+    @ParameterizedTest
+    @EnumSource(ErrorType::class)
+    @DisplayName("모든 에러 타입은 상호 배타적인 카테고리에 속한다")
+    fun shouldBelongToMutuallyExclusiveCategories(errorType: ErrorType) {
+        val isTransient = errorType.isTransient()
+        val isPermanent = errorType.isPermanent()
+        val isOther = !isTransient && !isPermanent
+        
+        val categoriesCount = listOf(isTransient, isPermanent, isOther).count { it }
+        assertEquals(
+            1,
+            categoriesCount,
+            "$errorType should belong to exactly one category"
+        )
+    }
+    
+    @Test
+    @DisplayName("재시도 가능한 타입은 일시적이거나 기타 카테고리에 속한다")
+    fun shouldHaveRetryableTypesInTransientOrOther() {
+        for (errorType in ErrorType.values()) {
+            if (errorType.isRetryable()) {
+                assertTrue(
+                    errorType.isTransient() || 
+                    (!errorType.isTransient() && !errorType.isPermanent()),
+                    "$errorType is retryable but not in transient or other category"
+                )
+            }
+        }
+    }
+    
+    @Test
+    @DisplayName("영구적 에러는 재시도 불가능하다")
+    fun shouldNotRetryPermanentErrors() {
+        for (errorType in ErrorType.values()) {
+            if (errorType.isPermanent()) {
+                assertFalse(
+                    errorType.isRetryable(),
+                    "$errorType is permanent but marked as retryable"
+                )
+            }
+        }
+    }
+}

--- a/kafka-dlq-handler-core/src/test/kotlin/io/github/kayden/dlq/core/model/ProcessingMetadataTest.kt
+++ b/kafka-dlq-handler-core/src/test/kotlin/io/github/kayden/dlq/core/model/ProcessingMetadataTest.kt
@@ -1,0 +1,355 @@
+package io.github.kayden.dlq.core.model
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+
+class ProcessingMetadataTest {
+    
+    @Test
+    @DisplayName("유효한 데이터로 ProcessingMetadata를 생성할 수 있다")
+    fun shouldCreateProcessingMetadataWithValidData() {
+        val metadata = ProcessingMetadata(
+            processedBy = "processor-1",
+            processingDurationMillis = 100L,
+            batchId = "batch-123",
+            attemptNumber = 2,
+            nextRetryAt = System.currentTimeMillis() + 60000,
+            backoffDelayMillis = 5000L,
+            tags = mapOf("env" to "prod", "region" to "us-east-1"),
+            metrics = ProcessingMetrics(messagesProcessed = 10)
+        )
+        
+        assertEquals("processor-1", metadata.processedBy)
+        assertEquals(100L, metadata.processingDurationMillis)
+        assertEquals("batch-123", metadata.batchId)
+        assertEquals(2, metadata.attemptNumber)
+        assertEquals(5000L, metadata.backoffDelayMillis)
+        assertEquals(2, metadata.tags.size)
+        assertNotNull(metadata.metrics)
+    }
+    
+    @Test
+    @DisplayName("기본값으로 ProcessingMetadata를 생성할 수 있다")
+    fun shouldCreateWithDefaults() {
+        val metadata = ProcessingMetadata()
+        
+        assertNull(metadata.processedBy)
+        assertNull(metadata.processingDurationMillis)
+        assertNull(metadata.batchId)
+        assertEquals(1, metadata.attemptNumber)
+        assertNull(metadata.nextRetryAt)
+        assertNull(metadata.backoffDelayMillis)
+        assertTrue(metadata.tags.isEmpty())
+        assertNull(metadata.metrics)
+    }
+    
+    @Test
+    @DisplayName("음수 시도 횟수로 생성 시 예외가 발생한다")
+    fun shouldThrowExceptionWhenAttemptNumberIsNonPositive() {
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetadata(attemptNumber = 0)
+        }.also { exception ->
+            assertEquals("Attempt number must be positive", exception.message)
+        }
+        
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetadata(attemptNumber = -1)
+        }
+    }
+    
+    @Test
+    @DisplayName("음수 처리 시간으로 생성 시 예외가 발생한다")
+    fun shouldThrowExceptionWhenProcessingDurationIsNegative() {
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetadata(processingDurationMillis = -1L)
+        }.also { exception ->
+            assertEquals("Processing duration must not be negative", exception.message)
+        }
+    }
+    
+    @Test
+    @DisplayName("음수 백오프 지연으로 생성 시 예외가 발생한다")
+    fun shouldThrowExceptionWhenBackoffDelayIsNegative() {
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetadata(backoffDelayMillis = -1L)
+        }.also { exception ->
+            assertEquals("Backoff delay must not be negative", exception.message)
+        }
+    }
+    
+    @Test
+    @DisplayName("단일 태그를 추가할 수 있다")
+    fun shouldAddSingleTag() {
+        val metadata = ProcessingMetadata()
+        val updated = metadata.withTag("key", "value")
+        
+        assertEquals(1, updated.tags.size)
+        assertEquals("value", updated.tags["key"])
+        assertTrue(metadata.tags.isEmpty())
+    }
+    
+    @Test
+    @DisplayName("여러 태그를 추가할 수 있다")
+    fun shouldAddMultipleTags() {
+        val metadata = ProcessingMetadata(tags = mapOf("existing" to "value"))
+        val newTags = mapOf("key1" to "value1", "key2" to "value2")
+        val updated = metadata.withTags(newTags)
+        
+        assertEquals(3, updated.tags.size)
+        assertEquals("value", updated.tags["existing"])
+        assertEquals("value1", updated.tags["key1"])
+        assertEquals("value2", updated.tags["key2"])
+    }
+    
+    @Test
+    @DisplayName("처리 시간을 올바르게 계산한다")
+    fun shouldCalculateProcessingTime() {
+        val metadata = ProcessingMetadata()
+        val startTime = 1000L
+        val endTime = 1500L
+        
+        val updated = metadata.withProcessingTime(startTime, endTime)
+        
+        assertEquals(500L, updated.processingDurationMillis)
+    }
+    
+    @Test
+    @DisplayName("종료 시간이 시작 시간보다 이전이면 예외가 발생한다")
+    fun shouldThrowExceptionWhenEndTimeBeforeStartTime() {
+        val metadata = ProcessingMetadata()
+        
+        assertThrows<IllegalArgumentException> {
+            metadata.withProcessingTime(1500L, 1000L)
+        }.also { exception ->
+            assertEquals("End time must be after start time", exception.message)
+        }
+    }
+    
+    @Test
+    @DisplayName("재시도 정보를 설정할 수 있다")
+    fun shouldSetRetryInfo() {
+        val metadata = ProcessingMetadata(attemptNumber = 2)
+        val nextRetryTime = System.currentTimeMillis() + 60000
+        val backoffDelay = 5000L
+        
+        val updated = metadata.withRetryInfo(nextRetryTime, backoffDelay)
+        
+        assertEquals(nextRetryTime, updated.nextRetryAt)
+        assertEquals(backoffDelay, updated.backoffDelayMillis)
+        assertEquals(3, updated.attemptNumber)
+    }
+    
+    @Test
+    @DisplayName("메트릭을 업데이트할 수 있다")
+    fun shouldUpdateMetrics() {
+        val metadata = ProcessingMetadata()
+        val metrics = ProcessingMetrics(messagesProcessed = 100)
+        
+        val updated = metadata.withMetrics(metrics)
+        
+        assertEquals(metrics, updated.metrics)
+    }
+    
+    @Test
+    @DisplayName("처리 완료 상태를 올바르게 판단한다")
+    fun shouldDetermineIfProcessed() {
+        val unprocessed = ProcessingMetadata()
+        assertFalse(unprocessed.isProcessed())
+        
+        val processed = ProcessingMetadata(processingDurationMillis = 100L)
+        assertTrue(processed.isProcessed())
+    }
+    
+    @Test
+    @DisplayName("재시도 예정 상태를 올바르게 판단한다")
+    fun shouldDetermineIfRetryScheduled() {
+        val notScheduled = ProcessingMetadata()
+        assertFalse(notScheduled.isRetryScheduled())
+        
+        val scheduled = ProcessingMetadata(nextRetryAt = System.currentTimeMillis() + 60000)
+        assertTrue(scheduled.isRetryScheduled())
+    }
+    
+    @Test
+    @DisplayName("EMPTY 상수가 올바르게 정의되어 있다")
+    fun shouldHaveEmptyConstant() {
+        val empty = ProcessingMetadata.EMPTY
+        
+        assertNull(empty.processedBy)
+        assertEquals(1, empty.attemptNumber)
+        assertTrue(empty.tags.isEmpty())
+        assertFalse(empty.isProcessed())
+        assertFalse(empty.isRetryScheduled())
+    }
+    
+    @Test
+    @DisplayName("initial 팩토리 메서드가 올바르게 동작한다")
+    fun shouldCreateInitialMetadata() {
+        val metadata = ProcessingMetadata.initial("processor-1", "batch-123")
+        
+        assertEquals("processor-1", metadata.processedBy)
+        assertEquals("batch-123", metadata.batchId)
+        assertEquals(1, metadata.attemptNumber)
+        
+        val withoutBatch = ProcessingMetadata.initial("processor-2")
+        assertEquals("processor-2", withoutBatch.processedBy)
+        assertNull(withoutBatch.batchId)
+    }
+}
+
+class ProcessingMetricsTest {
+    
+    @Test
+    @DisplayName("유효한 데이터로 ProcessingMetrics를 생성할 수 있다")
+    fun shouldCreateProcessingMetricsWithValidData() {
+        val metrics = ProcessingMetrics(
+            messagesProcessed = 100,
+            messagesSuccess = 95,
+            messagesFailed = 5,
+            bytesProcessed = 10240,
+            throughputMessagesPerSecond = 50.0,
+            averageProcessingTimeMillis = 20.0
+        )
+        
+        assertEquals(100, metrics.messagesProcessed)
+        assertEquals(95, metrics.messagesSuccess)
+        assertEquals(5, metrics.messagesFailed)
+        assertEquals(10240, metrics.bytesProcessed)
+        assertEquals(50.0, metrics.throughputMessagesPerSecond)
+        assertEquals(20.0, metrics.averageProcessingTimeMillis)
+    }
+    
+    @Test
+    @DisplayName("음수 값으로 생성 시 예외가 발생한다")
+    fun shouldThrowExceptionForNegativeValues() {
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetrics(messagesProcessed = -1)
+        }
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetrics(messagesSuccess = -1)
+        }
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetrics(messagesFailed = -1)
+        }
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetrics(bytesProcessed = -1)
+        }
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetrics(throughputMessagesPerSecond = -1.0)
+        }
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetrics(averageProcessingTimeMillis = -1.0)
+        }
+    }
+    
+    @Test
+    @DisplayName("성공+실패 메시지가 전체를 초과하면 예외가 발생한다")
+    fun shouldThrowExceptionWhenSuccessAndFailedExceedTotal() {
+        assertThrows<IllegalArgumentException> {
+            ProcessingMetrics(
+                messagesProcessed = 100,
+                messagesSuccess = 60,
+                messagesFailed = 50
+            )
+        }.also { exception ->
+            assertEquals("Success + Failed messages cannot exceed total processed", exception.message)
+        }
+    }
+    
+    @Test
+    @DisplayName("성공률을 올바르게 계산한다")
+    fun shouldCalculateSuccessRate() {
+        val metrics = ProcessingMetrics(
+            messagesProcessed = 100,
+            messagesSuccess = 95,
+            messagesFailed = 5
+        )
+        assertEquals(0.95, metrics.successRate())
+        
+        val noMessages = ProcessingMetrics()
+        assertNull(noMessages.successRate())
+    }
+    
+    @Test
+    @DisplayName("실패율을 올바르게 계산한다")
+    fun shouldCalculateFailureRate() {
+        val metrics = ProcessingMetrics(
+            messagesProcessed = 100,
+            messagesSuccess = 95,
+            messagesFailed = 5
+        )
+        assertEquals(0.05, metrics.failureRate())
+        
+        val noMessages = ProcessingMetrics()
+        assertNull(noMessages.failureRate())
+    }
+    
+    @Test
+    @DisplayName("메시지당 평균 바이트를 올바르게 계산한다")
+    fun shouldCalculateAverageBytesPerMessage() {
+        val metrics = ProcessingMetrics(
+            messagesProcessed = 100,
+            bytesProcessed = 10240
+        )
+        assertEquals(102.4, metrics.averageBytesPerMessage())
+        
+        val noMessages = ProcessingMetrics()
+        assertNull(noMessages.averageBytesPerMessage())
+    }
+    
+    @Test
+    @DisplayName("여러 메트릭을 올바르게 병합한다")
+    fun shouldMergeMetrics() {
+        val metrics1 = ProcessingMetrics(
+            messagesProcessed = 100,
+            messagesSuccess = 90,
+            messagesFailed = 10,
+            bytesProcessed = 1000,
+            throughputMessagesPerSecond = 50.0,
+            averageProcessingTimeMillis = 20.0
+        )
+        
+        val metrics2 = ProcessingMetrics(
+            messagesProcessed = 200,
+            messagesSuccess = 180,
+            messagesFailed = 20,
+            bytesProcessed = 2000,
+            throughputMessagesPerSecond = 60.0,
+            averageProcessingTimeMillis = 25.0
+        )
+        
+        val merged = ProcessingMetrics.merge(metrics1, metrics2)
+        
+        assertEquals(300, merged.messagesProcessed)
+        assertEquals(270, merged.messagesSuccess)
+        assertEquals(30, merged.messagesFailed)
+        assertEquals(3000, merged.bytesProcessed)
+        assertEquals(55.0, merged.throughputMessagesPerSecond)
+        assertEquals(22.5, merged.averageProcessingTimeMillis)
+    }
+    
+    @Test
+    @DisplayName("빈 메트릭 배열을 병합하면 EMPTY를 반환한다")
+    fun shouldReturnEmptyWhenMergingNoMetrics() {
+        val merged = ProcessingMetrics.merge()
+        assertEquals(ProcessingMetrics.EMPTY, merged)
+    }
+    
+    @Test
+    @DisplayName("null 평균값을 가진 메트릭을 병합할 수 있다")
+    fun shouldMergeMetricsWithNullAverages() {
+        val metrics1 = ProcessingMetrics(messagesProcessed = 100)
+        val metrics2 = ProcessingMetrics(
+            messagesProcessed = 200,
+            throughputMessagesPerSecond = 60.0
+        )
+        
+        val merged = ProcessingMetrics.merge(metrics1, metrics2)
+        
+        assertEquals(300, merged.messagesProcessed)
+        assertEquals(60.0, merged.throughputMessagesPerSecond)
+        assertNull(merged.averageProcessingTimeMillis)
+    }
+}


### PR DESCRIPTION
  ## 📋 작업 내용
  - DLQRecord data class 구현 (Core용, JPA 없음)
  - DLQStatus enum 구현 (7개 상태)
  - ErrorType enum 구현 (8개 타입)
  - ProcessingMetadata value object 구현
  - ProcessingMetrics data class 구현
  - 포괄적인 단위 테스트 작성

  ## 💬 리뷰 노트
  - ByteArray equals/hashCode 구현이 ID 기반으로 단순화되어 있습니다
  - ErrorType.fromException()의 매칭 로직이 적절한지 검토해주세요
  - ProcessingMetrics.merge() 구현이 성능에 적합한지 확인 부탁드립니다
